### PR TITLE
Fixed spacing in file list (.sopm)

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -280,7 +280,7 @@ function initGenerateFilelist(context) {
             }
 
             // Add file to FileList
-            fileListTemplate += `        <File Permission = "${permission}" Location = "${file}" />`;
+            fileListTemplate += `        <File Permission="${permission}" Location="${file}" />`;
 
             // Add a new line as long as there is a next file.
             if (filesList.length - 1 != i) {


### PR DESCRIPTION
I just used the “Insert Filelist to SOPM” function and saw that the spacing is a bit off.

Thanks for the great work and keep it up!