### PR TITLE
Fixed permissions in filelist generator.

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -420,7 +420,7 @@ function initGenerateFilelist(context) {
         filesList.sort().forEach(function (file, i) {
 
             let permission = '660';
-            if (file.startsWith('scripts/') || file.endsWith('.sh')) {
+            if (file.startsWith('bin/') || file.endsWith('.sh')) {
                 permission = '770';
             }
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -420,7 +420,7 @@ function initGenerateFilelist(context) {
         filesList.sort().forEach(function (file, i) {
 
             let permission = '660';
-            if (file.startsWith('bin/') || file.endsWith('.sh')) {
+            if (file.startsWith('scripts/') || file.startsWith('bin/') || file.endsWith('.sh')) {
                 permission = '770';
             }
 


### PR DESCRIPTION
When generating a filelist with help of this extension is the file permission wrong for script files like unit tests or selenium tests:

```
$ codepolicy
================================================================================
Code policy context:         OPM
Vendor:                      Znuny GmbH
Product name:                Znuny-QuickClose
================================================================================
Using up to 6 parallel processes.

Kernel/Config/Files/XML/ZnunyQuickClose.xml
Kernel/Language/de_ZnunyQuickClose.pm
Kernel/Language/nl_ZnunyQuickClose.pm
Kernel/Modules/AgentTicketZnunyQuickClose.pm
    [Warning] TidyAll::Plugin::Znuny::Perl::UTF8
        Check if file has UTF-8 encoding and consider adding "use utf8;" to prevent encoding problems.
README.md
Znuny-QuickClose.sopm
    [Error] TidyAll::Plugin::Znuny::SOPM::FileRights
        <File> tag has wrong permissions. Script files normally need 770 rights, the others 660.
        Line 34:         <File Permission="770" Location="scripts/test/ZnunyQuickClose/var/packagesetup/ZnunyQuickClose.t" />
...
```