### PR TITLE
Fixed spacing in generated filelist.

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -425,7 +425,7 @@ function initGenerateFilelist(context) {
             }
 
             // Add file to FileList
-            fileListTemplate += `        <File Permission="${permission}" Location="${file}" />`;
+            fileListTemplate += `        <File Permission="${permission}" Location="${file}"/>`;
 
             // Add a new line as long as there is a next file.
             if (filesList.length - 1 != i) {


### PR DESCRIPTION
There is a not needed space at the end of every file list entry which breaks the usage of VSCode extension and the Sublime extension:
```
$ git diff
diff --git a/Znuny-QuickClose.sopm b/Znuny-QuickClose.sopm
index cd15c99..e452f73 100755
--- a/Znuny-QuickClose.sopm
+++ b/Znuny-QuickClose.sopm
@@ -27,12 +27,12 @@ Additionally, you can fill dynamic fields via the link in the SysConfig.</Change
     <ChangeLog Version="1.4.1" Date="2015-11-11 09:02:57 UTC">changed documentation</ChangeLog>
     <ChangeLog Version="1.4.0" Date="2015-11-09 16:04:52 UTC">Ported to 5.0</ChangeLog>
     <Filelist>
-        <File Permission="660" Location="Kernel/Config/Files/XML/ZnunyQuickClose.xml"/>
-        <File Permission="660" Location="Kernel/Language/de_ZnunyQuickClose.pm"/>
-        <File Permission="660" Location="Kernel/Language/nl_ZnunyQuickClose.pm"/>
-        <File Permission="660" Location="Kernel/Modules/AgentTicketZnunyQuickClose.pm"/>
-        <File Permission="660" Location="scripts/test/ZnunyQuickClose/var/packagesetup/ZnunyQuickClose.t"/>
-        <File Permission="660" Location="var/packagesetup/ZnunyQuickClose.pm"/>
+        <File Permission="660" Location="Kernel/Config/Files/XML/ZnunyQuickClose.xml" />
+        <File Permission="660" Location="Kernel/Language/de_ZnunyQuickClose.pm" />
+        <File Permission="660" Location="Kernel/Language/nl_ZnunyQuickClose.pm" />
+        <File Permission="660" Location="Kernel/Modules/AgentTicketZnunyQuickClose.pm" />
+        <File Permission="770" Location="scripts/test/ZnunyQuickClose/var/packagesetup/ZnunyQuickClose.t" />
+        <File Permission="660" Location="var/packagesetup/ZnunyQuickClose.pm" />
     </Filelist>

```